### PR TITLE
Add bundle method

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,6 @@
     "finn-prettier"
   ],
   "env": {
-    "node": true,
     "jest": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm install asset-pipe-css-writer
 ### Require the writer
 
 ```js
-const CssWriter = require('asset-pipe-css-writer');
+const CssWriter = require('@asset-pipe/css-writer');
 ```
 
 ### Instantiating the writer
@@ -82,12 +82,12 @@ const writer = new CssWriter([
 
 ### Consuming content from the writer
 
-The writer is a readable stream in object mode so in order to access the data
-you may register a data handler and listen for objects to be passed to the
-handler:
+The writer is an event emitter, which has a method called `bundle`, which
+returns a readable stream in object mode so in order to access the data you may
+register a data handler and listen for objects to be passed to the handler:
 
 ```js
-writer.on('data', data => {
+writer.bundle().on('data', data => {
     // { id, name, version, file, content }
 });
 ```
@@ -96,7 +96,7 @@ You might also pipe the writer into a writeable or transform stream (with input
 in object mode):
 
 ```js
-const { Writable } = require('stream');
+const { Writeable } = require('stream');
 const consumer = new Writeable({
     objectMode: true,
     write(chunk, encoding, callback) {
@@ -106,5 +106,19 @@ const consumer = new Writeable({
     },
 });
 
-writer.pipe(consumer);
+writer.bundle().pipe(consumer);
+```
+
+If you want to create a single file output, send `true` as the second argument
+when creating the `Writer`.
+
+```js
+const writer = new CssWriter(
+    ['/path/to/css/file1.css', '/path/to/css/file2.css'],
+    true,
+);
+
+writer.bundle().on('data', data => {
+    // the two files bundled together as a single CSS
+});
 ```

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -27,9 +27,7 @@ class Stream extends Readable {
                 bundleCssModule(file),
                 identifyCssModule(file),
             ]);
-            meta.id = hasher(
-                `${meta.name}|${meta.version}|${meta.file}|${css}`
-            );
+            meta.id = hasher(css);
             meta.content = css;
             this.push(meta);
         } catch (err) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,15 +1,47 @@
 'use strict';
 
-const { Readable } = require('stream');
+const EventEmitter = require('events');
+const { Readable, Transform } = require('stream');
 const { identifyCssModule, bundleCssModule } = require('./util');
 const { existsSync } = require('fs');
 const { isAbsolute } = require('path');
 const assert = require('assert');
 const { hasher } = require('asset-pipe-common');
 
-module.exports = class Writer extends Readable {
-    constructor(files = []) {
+class Stream extends Readable {
+    constructor(files) {
         super({ objectMode: true });
+
+        this.files = files;
+    }
+
+    async _read() {
+        const file = this.files.shift();
+        if (!file) {
+            this.push(null);
+            return;
+        }
+
+        try {
+            const [css, meta] = await Promise.all([
+                bundleCssModule(file),
+                identifyCssModule(file),
+            ]);
+            meta.id = hasher(
+                `${meta.name}|${meta.version}|${meta.file}|${css}`
+            );
+            meta.content = css;
+            this.push(meta);
+        } catch (err) {
+            this.emit('error', err);
+        }
+    }
+}
+
+module.exports = class Writer extends EventEmitter {
+    constructor(files = [], bundle = false) {
+        super({ objectMode: true });
+        this.shouldBundle = bundle;
 
         assert(
             Array.isArray(files) || typeof files === 'string',
@@ -38,25 +70,20 @@ module.exports = class Writer extends Readable {
         }
     }
 
-    async _read() {
-        const file = this.files.shift();
-        if (!file) {
-            this.push(null);
-            return;
+    bundle() {
+        const cssStream = new Stream(this.files.slice(0));
+
+        if (!this.shouldBundle) {
+            return cssStream;
         }
 
-        try {
-            const [css, meta] = await Promise.all([
-                bundleCssModule(file),
-                identifyCssModule(file),
-            ]);
-            meta.id = hasher(
-                `${meta.name}|${meta.version}|${meta.file}|${css}`
-            );
-            meta.content = css;
-            this.push(meta);
-        } catch (err) {
-            this.emit('error', err);
-        }
+        return cssStream.pipe(
+            new Transform({
+                objectMode: true,
+                transform(chunk, enc, next) {
+                    next(null, chunk.content);
+                },
+            })
+        );
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,7 +294,7 @@
             "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
             "requires": {
                 "delegates": "1.0.0",
-                "readable-stream": "2.3.2"
+                "readable-stream": "2.3.3"
             }
         },
         "argparse": {
@@ -382,6 +382,22 @@
             "integrity": "sha1-N90Dk6Owb2IU6LHg1lbKGegiyE8=",
             "requires": {
                 "readable-stream": "2.3.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+                    "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                }
             }
         },
         "astral-regex": {
@@ -1202,7 +1218,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.2",
+                "readable-stream": "2.3.3",
                 "typedarray": "0.0.6"
             }
         },
@@ -5617,9 +5633,9 @@
             }
         },
         "readable-stream": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-            "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -6412,7 +6428,7 @@
                 "fstream": "1.0.11",
                 "fstream-ignore": "1.0.5",
                 "once": "1.4.0",
-                "readable-stream": "2.3.2",
+                "readable-stream": "2.3.3",
                 "rimraf": "2.6.2",
                 "tar": "2.2.1",
                 "uid-number": "0.0.6"
@@ -6537,7 +6553,7 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.2",
+                "readable-stream": "2.3.3",
                 "xtend": "4.0.1"
             }
         },

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -61,7 +61,6 @@ test('bundleCssModule(filePath)', async () => {
 test('new Writer(filePath)', done => {
     expect.assertions(2);
     const filePath = path.join(__dirname, 'test-assets/my-module-1/main.css');
-    const fileRef = 'my-module-1/main.css';
 
     const writer = new Writer(filePath).bundle();
     const items = [];
@@ -73,9 +72,7 @@ test('new Writer(filePath)', done => {
     writer.on('end', () => {
         const result1 = items[0];
         const result2 = items[1];
-        expect(result1.id).toBe(
-            hasher(`my-module-1|1.0.1|${fileRef}|${result1.content}`)
-        );
+        expect(result1.id).toBe(hasher(result1.content));
         expect(result2).toBeFalsy();
         done();
     });
@@ -118,7 +115,6 @@ test('new Writer(filePath) relative paths throw error', () => {
 test('new Writer([filePath])', done => {
     expect.assertions(2);
     const filePath = path.join(__dirname, 'test-assets/my-module-1/main.css');
-    const fileRef = 'my-module-1/main.css';
 
     const writer = new Writer([filePath]).bundle();
     const items = [];
@@ -130,9 +126,7 @@ test('new Writer([filePath])', done => {
     writer.on('end', () => {
         const result1 = items[0];
         const result2 = items[1];
-        expect(result1.id).toBe(
-            hasher(`my-module-1|1.0.1|${fileRef}|${result1.content}`)
-        );
+        expect(result1.id).toBe(hasher(result1.content));
         expect(result2).toBeFalsy();
         done();
     });
@@ -144,7 +138,6 @@ test('Writer processes @import statements', done => {
         __dirname,
         'test-assets/my-module-3/css/main.css'
     );
-    const fileRef = 'my-module-3/css/main.css';
 
     const writer = new Writer([filePath]).bundle();
     const items = [];
@@ -157,9 +150,7 @@ test('Writer processes @import statements', done => {
         const result1 = items[0];
         const result2 = items[1];
 
-        expect(result1.id).toBe(
-            hasher(`my-module-3|1.0.1|${fileRef}|${result1.content}`)
-        );
+        expect(result1.id).toBe(hasher(result1.content));
         expect(result1.content).toMatch('my-module-3/main.css');
         expect(result1.content).toMatch('my-module-3/dep.css');
         expect(result1.content).toMatch('dep/main.css');
@@ -171,12 +162,10 @@ test('Writer processes @import statements', done => {
 test('new Writer([filePath1, filePath2]) ensures correct order', done => {
     expect.assertions(3);
     const filePath1 = path.join(__dirname, 'test-assets/my-module-1/main.css');
-    const fileRef1 = 'my-module-1/main.css';
     const filePath2 = path.join(
         __dirname,
         'test-assets/my-module-2/css/main.css'
     );
-    const fileRef2 = 'my-module-2/css/main.css';
 
     const writer = new Writer([filePath1, filePath2]).bundle();
     const items = [];
@@ -190,12 +179,8 @@ test('new Writer([filePath1, filePath2]) ensures correct order', done => {
         const result2 = items[1];
         const result3 = items[2];
 
-        expect(result1.id).toBe(
-            hasher(`my-module-1|1.0.1|${fileRef1}|${result1.content}`)
-        );
-        expect(result2.id).toBe(
-            hasher(`my-module-2|1.0.1|${fileRef2}|${result2.content}`)
-        );
+        expect(result1.id).toBe(hasher(result1.content));
+        expect(result2.id).toBe(hasher(result2.content));
         expect(result3).toBeFalsy();
         done();
     });


### PR DESCRIPTION
## JIRA Issue
[COREWEB-10](https://jira.finn.no/browse/COREWEB-10)

## Status
**READY**

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This adds a new method called `bundle` on the exported class. This make the module match the API of the JS writer.

In particular it enables us to instantiate a `CssWriter` a single time, but consume from it multiple times.

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->

## Related PRs
* None
